### PR TITLE
Better handling of cluster-scoped template lookups

### DIFF
--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -1027,6 +1027,11 @@ func (r *PolicyReconciler) processTemplates(
 
 	templateCfg := getTemplateCfg()
 	templateCfg.LookupNamespace = rootPlc.GetNamespace()
+	templateCfg.ClusterScopedAllowList = []templates.ClusterScopedObjectIdentifier{{
+		Group: "cluster.open-cluster-management.io",
+		Kind:  "ManagedCluster",
+		Name:  decision.ClusterName,
+	}}
 
 	tmplResolver, err := templates.NewResolver(kubeClient, kubeConfig, templateCfg)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/prometheus/client_golang v1.15.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
-	github.com/stolostron/go-template-utils/v3 v3.2.1
-	github.com/stolostron/kubernetes-dependency-watches v0.2.1
+	github.com/stolostron/go-template-utils/v3 v3.3.0
+	github.com/stolostron/kubernetes-dependency-watches v0.3.0
 	github.com/stretchr/testify v1.8.1
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -175,10 +175,10 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRDmX5sO29c=
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
-github.com/stolostron/go-template-utils/v3 v3.2.1 h1:wRiCgHG1pcRYa4ZOb/rbzP45Quh8ChNrqXjHDsSaTQg=
-github.com/stolostron/go-template-utils/v3 v3.2.1/go.mod h1:D9uOV787ztGsIqh4FxZzkPfBQgy2zz9vK0cv8uDO5vM=
-github.com/stolostron/kubernetes-dependency-watches v0.2.1 h1:42oLxw+wm/LxHj/3WkJOpyry6dy9Svwgm6jHCttQ6qs=
-github.com/stolostron/kubernetes-dependency-watches v0.2.1/go.mod h1:u2NLFgX12/XwNJvxBpqEhfwGwx8dHWGPxzpDy5L3DIk=
+github.com/stolostron/go-template-utils/v3 v3.3.0 h1:A+Se/7RekQe1h1HkIwG/XLwo7HIG7fs4Nnn52gww1Lg=
+github.com/stolostron/go-template-utils/v3 v3.3.0/go.mod h1:D9uOV787ztGsIqh4FxZzkPfBQgy2zz9vK0cv8uDO5vM=
+github.com/stolostron/kubernetes-dependency-watches v0.3.0 h1:6Ko9bj1EvtavgkpKQdpG1fOgtVkMNBzr2QsBsLNvWdo=
+github.com/stolostron/kubernetes-dependency-watches v0.3.0/go.mod h1:u2NLFgX12/XwNJvxBpqEhfwGwx8dHWGPxzpDy5L3DIk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/test/resources/case9_templates/case9-test-policy-cslookup.yaml
+++ b/test/resources/case9_templates/case9-test-policy-cslookup.yaml
@@ -1,0 +1,59 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case9-test-policy-cslookup
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case9-test-configpolicy
+        spec:
+          remediationAction: inform
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: case9-test-configmap
+                  namespace: test
+                data:
+                  namespace-phase: |
+                    {{hub (lookup "v1" "Namespace" "" "case9-test").status.phase hub}}
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case9-test-policy-cslookup-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case9-test-policy-cslookup-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case9-test-policy-cslookup
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case9-test-policy-cslookup-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: case9-test

--- a/test/resources/case9_templates/case9-test-policy.yaml
+++ b/test/resources/case9_templates/case9-test-policy.yaml
@@ -36,6 +36,8 @@ spec:
                     {{hub fromConfigMap "policy-propagator-test" "case9-config2" "saying" | base64dec | autoindent hub}}
                   label-vendor-test: |
                     {{hub .ManagedClusterLabels.vendor hub}}
+                  label-vendor-test-two: |
+                    {{hub (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.labels.vendor hub}}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/case9_templates/case9-test-replpolicy-managed1-relabelled.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed1-relabelled.yaml
@@ -38,3 +38,5 @@ spec:
                     There is no try.
                   label-vendor-test: |
                     Fake
+                  label-vendor-test-two: |
+                    Fake

--- a/test/resources/case9_templates/case9-test-replpolicy-managed1.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed1.yaml
@@ -38,3 +38,5 @@ spec:
                     There is no try.
                   label-vendor-test: |
                     auto-detect
+                  label-vendor-test-two: |
+                    auto-detect

--- a/test/resources/case9_templates/case9-test-replpolicy-managed2.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed2.yaml
@@ -38,3 +38,5 @@ spec:
                     There is no try.
                   label-vendor-test: |
                     auto-detect
+                  label-vendor-test-two: |
+                    auto-detect


### PR DESCRIPTION
Previously, there were some inconsistencies in how a hub template lookup for a cluster-scoped resource worked. As a result, the propagator would throw an error, and not be able to populate a real status for policies that tried to use that kind of lookup.

Now, in general, using lookup in a hub template for a cluster-scoped resource will fail with a template error that can be seen in the propagated policy. The one current exception is that a lookup of the ManagedCluster where the policy is replicated is allowed.

Refs:
 - https://issues.redhat.com/browse/ACM-5547